### PR TITLE
add functionality for custom quality labels

### DIFF
--- a/scripts/html5.js
+++ b/scripts/html5.js
@@ -650,7 +650,7 @@ H5P.VideoHtml5 = (function ($) {
           // Create a new quality tag
           source.quality = {
             name: 'q' + qualityIndex,
-            label: 'Quality ' + qualityIndex // TODO: l10n
+            label: (source.metadata && source.metadata.qualityName) ? source.metadata.qualityName : 'Quality ' + qualityIndex // TODO: l10n
           };
           qualityIndex++;
         }
@@ -706,7 +706,7 @@ H5P.VideoHtml5 = (function ($) {
   };
 
   /**
-   * Set preferred video quality.
+   * Get preferred video quality.
    *
    * @private
    * @static


### PR DESCRIPTION
implements [custom video quality labels as requested and discussed in the forum](https://h5p.org/node/44733)

requires [pull request for h5p-editor-php-library](https://github.com/h5p/h5p-editor-php-library/pull/29) and [pull request for h5p-interactive-video](https://github.com/h5p/h5p-interactive-video/pull/47)