### PR TITLE
crossorigin attribute not set if crossorigin policy is 'null'

### DIFF
--- a/scripts/html5.js
+++ b/scripts/html5.js
@@ -73,12 +73,14 @@ H5P.VideoHtml5 = (function ($) {
 
     if (H5P.getCrossOrigin !== undefined) {
       var crossOrigin = H5P.getCrossOrigin(qualities[currentQuality].source.path);
-      video.setAttribute('crossorigin', crossOrigin !== null ? crossOrigin : 'anonymous');
+      if (crossOrigin !== 'null') {
+        video.setAttribute('crossorigin', crossOrigin !== null ? crossOrigin : 'anonymous');
+      }
     }
 
     video.src = qualities[currentQuality].source.path;
 
-    // Setting webkit-playsinline, which makes iOS 10 beeing able to play video
+    // Setting webkit-playsinline, which makes iOS 10 being able to play video
     // inside browser.
     video.setAttribute('webkit-playsinline', '');
     video.setAttribute('playsinline', '');


### PR DESCRIPTION
This change allows website/LMS administrators to disable CORS for videos by settings certain configuration options. The current default behavior of setting it to 'anonymous' is not changed. The options needed to disable CORS are: 
```
H5PIntegration.crossorigin = 'null'
H5PIntegration.crossoriginRegex = '.*' // or any other regex string depending on which websites CORS should be disabled for
```

Using this option might be necessary in situations in which you can't work with the 'anonymous' or 'use-credentials' values of the ``crossorigin`` attribute of the video element (e.g. because a server with required content returns invalid Access-Control-Allow-Origin values or because there is a redirect from a server requiring 'use-credentials' to a server requiring 'anonymous'). 

This change fixes [Github issue #230 of h5p-moodle-plugin](https://github.com/h5p/h5p-moodle-plugin/issues/230).

To get this change working on moodle a pull request that [gets H5PIntegration.crossoriginRegex from the config.php file](https://github.com/h5p/h5p-moodle-plugin/pull/245) must be accepted first. (This is a bug in the h5p-moodle-plugin.)