### PR TITLE
Minor spelling change

### DIFF
--- a/language/es-mx.json
+++ b/language/es-mx.json
@@ -38,7 +38,7 @@
       "fields": [
         {
           "label": "Nombre",
-          "default": "Video",
+          "default": "Vídeo",
           "description": "Ayuda a identificar el contenido de este tipo."
         },
         {

--- a/language/es.json
+++ b/language/es.json
@@ -38,7 +38,7 @@
       "fields": [
         {
           "label": "Nombre",
-          "default": "Video",
+          "default": "Vídeo",
           "description": "Ayuda a identificar el contenido de este tipo."
         },
         {


### PR DESCRIPTION
This minor change in spelling will achieve a 100% translation of strings reported in https://localization.h5p.org/es-mx/H5P.Video/

BUT, can you please tell me how can I achieve a 100% translation coverage (for other H5P plugins) when one (or more) English language strings are exactly the same in Spanish language (e.g, panel ) ?

