### PR TITLE
Fix crash when video cannot be played

### DIFF
--- a/scripts/html5.js
+++ b/scripts/html5.js
@@ -66,6 +66,10 @@ H5P.VideoHtml5 = (function ($) {
      * @private
      */
     const setInitialSource = function () {
+      if (qualities[currentQuality] === undefined) {
+        return;
+      }
+
       if (H5P.setSource !== undefined) {
         H5P.setSource(video, qualities[currentQuality].source, self.contentId)
       }


### PR DESCRIPTION
When the video cannot be played, there's no quality setting and hence no source that can be played resulting in a crash when setting the source. Fixed.