### PR TITLE
Added Youtube looping in BS and VT

### DIFF
--- a/scripts/youtube.js
+++ b/scripts/youtube.js
@@ -64,6 +64,7 @@ H5P.VideoYouTube = (function ($) {
           controls: options.controls ? 1 : 0,
           disablekb: options.controls ? 0 : 1,
           fs: 0,
+          loop: options.loop ? 1 : 0,
           playlist: options.loop ? videoId : undefined,
           rel: 0,
           showinfo: 0,


### PR DESCRIPTION
Youtube videos weren't loop correctly in these content types. This correctly implements the Youtube embed as documented here with both the `playlist` and `loop` attributes - https://developers.google.com/youtube/player_parameters#loop