### PR TITLE
Enable fullscreen button for embedded youtube-videos

### DIFF
--- a/library.json
+++ b/library.json
@@ -7,7 +7,7 @@
   "author": "Joubel",
   "majorVersion": 1,
   "minorVersion": 5,
-  "patchVersion": 18,
+  "patchVersion": 19,
   "runnable": 0,
   "coreApi": {
     "majorVersion": 1,

--- a/scripts/youtube.js
+++ b/scripts/youtube.js
@@ -11,7 +11,7 @@ H5P.VideoYouTube = (function ($) {
    */
   function YouTube(sources, options, l10n) {
     var self = this;
-
+    
     var player;
     var playbackRate = 1;
     var id = 'h5p-youtube-' + numInstances;
@@ -63,7 +63,7 @@ H5P.VideoYouTube = (function ($) {
           autoplay: options.autoplay ? 1 : 0,
           controls: options.controls ? 1 : 0,
           disablekb: options.controls ? 0 : 1,
-          fs: 0,
+          fs: 1,
           loop: options.loop ? 1 : 0,
           playlist: options.loop ? videoId : undefined,
           rel: 0,


### PR DESCRIPTION
A simple change in youtube.js that enables the fullscreen-button by default for embedded youtube-videos. As of now, the fullscreen-button does not show.