### PR TITLE
HFP-3684 Prevent playback rate spoofing

### DIFF
--- a/scripts/echo360.js
+++ b/scripts/echo360.js
@@ -517,7 +517,7 @@ H5P.VideoEchoVideo = (() => {
      * @returns {Array} Available playback rates
      */
     this.getPlaybackRates = () => {
-      return [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2];
+      return H5P.Video.DEFAULT_PLAYBACK_RATES;
     };
 
     /**
@@ -538,6 +538,11 @@ H5P.VideoEchoVideo = (() => {
      */
     this.setPlaybackRate = async (rate) => {
       const echoRate = parseFloat(rate);
+
+      if (self.getPlaybackRates().indexOf(echoRate) === -1) {
+        return;
+      }
+
       this.post('playbackrate', echoRate);
       playbackRate = rate;
       this.trigger('playbackRateChange', rate);

--- a/scripts/html5.js
+++ b/scripts/html5.js
@@ -608,13 +608,7 @@ H5P.VideoHtml5 = (function ($) {
      * @returns {Array} available playback rates
      */
     self.getPlaybackRates = function () {
-      /*
-       * not sure if there's a common rule about determining good speeds
-       * using Google's standard options via a constant for setting
-       */
-      var playbackRates = PLAYBACK_RATES;
-
-      return playbackRates;
+      return H5P.Video.DEFAULT_PLAYBACK_RATES;
     };
 
     /**
@@ -632,9 +626,15 @@ H5P.VideoHtml5 = (function ($) {
      * Listen to event "playbackRateChange" to check if successful.
      *
      * @public
-     * @params {Number} suggested rate that may be rounded to supported values
+     * @params {Number|string} newPlaybackRate Suggested rate that may be rounded to supported values.
      */
     self.setPlaybackRate = function (newPlaybackRate) {
+      newPlaybackRate = Number(newPlaybackRate); // argument may be string
+
+      if (self.getPlaybackRates().indexOf(newPlaybackRate) === -1) {
+        return;
+      }
+
       playbackRate = newPlaybackRate;
       video.playbackRate = newPlaybackRate;
     };
@@ -927,9 +927,6 @@ H5P.VideoHtml5 = (function ($) {
 
   /** @constant {Boolean} */
   var PREFERRED_FORMAT = 'mp4';
-
-  /** @constant {Object} */
-  var PLAYBACK_RATES = [0.25, 0.5, 1, 1.25, 1.5, 2];
 
   if (navigator.userAgent.indexOf('Android') !== -1) {
     // We have Android, check version.

--- a/scripts/panopto.js
+++ b/scripts/panopto.js
@@ -402,17 +402,23 @@ H5P.VideoPanopto = (function ($) {
      * @returns {Array} available playback rates
      */
     self.getPlaybackRates = function () {
-      return [0.25, 0.5, 1, 1.25, 1.5, 2];
+      return H5P.Video.DEFAULT_PLAYBACK_RATES;
     };
 
     /**
      * Get current playback rate.
      *
      * @public
-     * @returns {Number} such as 0.25, 0.5, 1, 1.25, 1.5 and 2
+     * @params {Number|string} newPlaybackRate Suggested rate that may be rounded to supported values.
      */
-    self.getPlaybackRate = function () {
+    self.getPlaybackRate = function (newPlaybackRate) {
       if (!player || !player.getPlaybackRate) {
+        return;
+      }
+
+      newPlaybackRate = Number(newPlaybackRate); // argument may be string
+
+      if (self.getPlaybackRates().indexOf(newPlaybackRate) === -1) {
         return;
       }
 

--- a/scripts/video.js
+++ b/scripts/video.js
@@ -326,5 +326,8 @@ H5P.Video = (function ($, ContentCopyrights, MediaCopyright, handlers) {
   /** @constant {Boolean} */
   Video.IE11_PLAYBACK_RATE_FIX = (navigator.userAgent.match(/Trident.*rv[ :]*11\./) ? true : false);
 
+  /** @constant {Number[]} */
+  Video.DEFAULT_PLAYBACK_RATES = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 2];
+
   return Video;
 })(H5P.jQuery, H5P.ContentCopyrights, H5P.MediaCopyright, H5P.videoHandlers || []);

--- a/scripts/vimeo.js
+++ b/scripts/vimeo.js
@@ -449,7 +449,11 @@ H5P.VideoVimeo = (function ($) {
      * @returns {Array} Available playback rates
      */
     self.getPlaybackRates = () => {
-      return [0.5, 1, 1.5, 2];
+      /*
+       * Vimeo Player SDK only supports the interval [0.5, 2],
+       * see https://developer.vimeo.com/player/sdk/reference#methods-for-playback-controls
+       */
+      return H5P.Video.DEFAULT_PLAYBACK_RATES.filter((rate) => rate >= 0.5 && rate <= 2);
     };
 
     /**

--- a/scripts/vimeo.js
+++ b/scripts/vimeo.js
@@ -466,9 +466,15 @@ H5P.VideoVimeo = (function ($) {
      * Set the current playback rate.
      *
      * @public
-     * @param {Number} rate Must be one of available rates from getPlaybackRates
+     * @param {Number|string} rate Must be one of available rates from getPlaybackRates.
      */
     self.setPlaybackRate = async (rate) => {
+      rate = Number(rate);
+
+      if (self.getPlaybackRates().indexOf(rate) === -1) {
+        return;
+      }
+
       playbackRate = await player.setPlaybackRate(rate);
       self.trigger('playbackRateChange', rate);
     };

--- a/scripts/youtube.js
+++ b/scripts/youtube.js
@@ -480,7 +480,7 @@ H5P.VideoYouTube = (function ($) {
      * Listen to event "playbackRateChange" to check if successful.
      *
      * @public
-     * @params {Number} suggested rate that may be rounded to supported values
+     * @params {Number|string} newPlaybackRate suggested rate that may be rounded to supported values.
      */
     self.setPlaybackRate = function (newPlaybackRate) {
       if (!player || !player.setPlaybackRate) {
@@ -488,6 +488,11 @@ H5P.VideoYouTube = (function ($) {
       }
 
       playbackRate = Number(newPlaybackRate);
+
+      if ((self.getPlaybackRates() || []).indexOf(playbackRate) === -1) {
+        return;
+      }
+
       player.setPlaybackRate(playbackRate);
     };
 


### PR DESCRIPTION
When merged in, will not set the playback rate requested unless it is among the predefined (allowed) playback rates.

Currently, the user can override the `playback-rate` attribute of Interactive Video's playback rate chooser in HTML by any arbitrary number. That way, the video could be played at a rate way higher than allowed which may undermine the prevent skipping option.