### PR TITLE
HFP-4037 Fix sanitization of visual parameters

### DIFF
--- a/scripts/video.js
+++ b/scripts/video.js
@@ -53,9 +53,9 @@ H5P.Video = (function ($, ContentCopyrights, MediaCopyright, handlers) {
 
     parameters.a11y = parameters.a11y || [];
     parameters.playback = parameters.playback || {};
-    parameters.visuals = $.extend(true, parameters.visuals, {
-      disableFullscreen: false
-    });
+    parameters.visuals = $.extend(
+      true, { disableFullscreen: false }, parameters.visuals
+    );
 
     /** @private */
     var sources = [];


### PR DESCRIPTION
When merged in, will fix setting the default value for `visuals.disableFullscreen` during sanitization.

The idea of the current code is to allow the video to be sent to full screen by default (https://github.com/h5p/h5p-video/commit/21b6d045782f998dd5322e6b57cfa4815dc0d979). However, jQuery's `extend` function will overwrite the `disableFullscreen` with `false` (3rd argument) in any case - even if it is set to `true` in the target parameter (2nd argument). That means that setting the parameter (by a parent content type) has no effect.

Fixed by reversing the order of the 2nd and the 3rd argument of `extend`, so `disableFullscreen: false` is set by default, but will be overridden if the content parameters supply a value for `disableFullscreen`.