### PR TITLE
HFP-4079 Work around server sending multipt init events

### DIFF
--- a/scripts/echo360.js
+++ b/scripts/echo360.js
@@ -109,14 +109,21 @@ H5P.VideoEchoVideo = (() => {
         if (message.event === 'init') {
           duration = message.data.duration;
           this.setCurrentTime(message.data.currentTime ?? 0);
-          qualities = mapQualityLevels(message.data.qualityOptions);
-          currentQuality = qualities[0].name;
           player.resolveLoading();
-          this.trigger('qualityChange', currentQuality);
+
+          // Player sends `init` event after rebuffering, unfortunately.
+          if (!this.wasInitialized) {
+            qualities = mapQualityLevels(message.data.qualityOptions);
+            currentQuality = qualities[0].name;
+            this.trigger('qualityChange', currentQuality);
+          }
+
           this.trigger('resize');
           if (message.data.playing) {
             changeState(H5P.Video.PLAYING);
           }
+
+          this.wasInitialized = true;
         }
         else if (message.event === 'timeline') {
           duration = message.data.duration ?? this.getDuration();


### PR DESCRIPTION
When merged in, will add a workaround to the player/server sending `init` events after re-buffering in order to keep the current quality setting.