### PR TITLE
HFP-4103 Add guard against time jumping back and forth

### DIFF
--- a/scripts/echo360.js
+++ b/scripts/echo360.js
@@ -133,19 +133,19 @@ H5P.VideoEchoVideo = (() => {
             );
           }
           player.resolveLoading();
-          
+
           // Player sends `init` event after rebuffering, unfortunately.
           if (!this.wasInitialized) {
             qualities = mapQualityLevels(message.data.qualityOptions);
             currentQuality = qualities[0].name;
             this.trigger('qualityChange', currentQuality);
           }
-          
+
           this.trigger('resize');
           if (message.data.playing) {
             changeState(H5P.Video.PLAYING);
           }
-          
+
           this.wasInitialized = true;
         }
         else if (message.event === 'timeline') {

--- a/scripts/echo360.js
+++ b/scripts/echo360.js
@@ -34,6 +34,8 @@ H5P.VideoEchoVideo = (() => {
 
     const timeUpdateIntervalDefaultMs = 40; // 25 fps by default
     let timeUpdateIntervalMs = timeUpdateIntervalDefaultMs;
+    const previousTimes = []; // Buffer for previous times to prevent jumps
+    const previousTimesBuffer = 2;
 
     /*
      * Echo360 player does send time updates ~ 0.25 seconds by default and
@@ -261,7 +263,7 @@ H5P.VideoEchoVideo = (() => {
         }
 
         const delta = Date.now() - this.lastTimeUpdate;
-        this.setCurrentTime(currentTime + delta / 1000);
+        this.setCurrentTimeGuarded(currentTime + delta / 1000);
         timeUpdate(currentTime);
       }, timeUpdateIntervalMs);
     }
@@ -438,6 +440,38 @@ H5P.VideoEchoVideo = (() => {
     this.setCurrentTime = (timeS) => {
       currentTime = timeS;
     }
+
+    /**
+     * Set current time with guard against Echo360's delayed time updates.
+     * @param {number} timeS Time in seconds.
+     * @returns
+     */
+    this.setCurrentTimeGuarded = (timeS) => {
+      const maxIndex = previousTimes.length - 1;
+
+      // Prevent currentTime from jumping back and forth
+      if (
+        previousTimes[maxIndex - 1] < previousTimes[maxIndex] &&
+        previousTimes[maxIndex] > timeS &&
+        previousTimes[maxIndex - 1] <= timeS // Allow seeking back
+      ) {
+        return;
+      }
+      this.updatePreviousTimes(currentTime);
+
+      this.setCurrentTime(timeS);
+    }
+
+    /**
+     * Update previous times storage.
+     * @param {number} timeS Time in seconds to store.
+     */
+    this.updatePreviousTimes = (timeS) => {
+      if (previousTimes.length >= previousTimesBuffer) {
+        previousTimes.shift();
+      }
+      previousTimes.push(timeS);
+    };
 
     /**
      * Return the video duration.

--- a/scripts/echo360.js
+++ b/scripts/echo360.js
@@ -32,6 +32,9 @@ H5P.VideoEchoVideo = (() => {
     let timelineUpdatesToSkip = 0;
     let timeUpdateTimeout;
 
+    const timeUpdateIntervalDefaultMs = 40; // 25 fps by default
+    let timeUpdateIntervalMs = timeUpdateIntervalDefaultMs;
+
     /*
      * Echo360 player does send time updates ~ 0.25 seconds by default and
      * ends playing the video without sending a final time update or an
@@ -260,7 +263,7 @@ H5P.VideoEchoVideo = (() => {
         const delta = Date.now() - this.lastTimeUpdate;
         this.setCurrentTime(currentTime + delta / 1000);
         timeUpdate(currentTime);
-      }, 40); // 25 fps
+      }, timeUpdateIntervalMs);
     }
 
     /**
@@ -540,6 +543,13 @@ H5P.VideoEchoVideo = (() => {
       const echoRate = parseFloat(rate);
       this.post('playbackrate', echoRate);
       playbackRate = rate;
+
+      // Reduce time update interval for slower playback
+      timeUpdateIntervalMs = Math.max(
+        timeUpdateIntervalDefaultMs,
+        timeUpdateIntervalDefaultMs / rate
+      );
+
       this.trigger('playbackRateChange', rate);
     };
 


### PR DESCRIPTION
When merged in, should prevent the time(line) to jump back and forth if one time event is off due to player delay.