### PR TITLE
HFP-4174 Allow Panopto videos from self-hosted Panopto instances

### DIFF
--- a/scripts/panopto.js
+++ b/scripts/panopto.js
@@ -516,7 +516,7 @@ H5P.VideoPanopto = (function ($) {
    * @returns {String} Panopto video identifier
    */
   var getId = function (url) {
-    const matches = url.match(/^[^\/]+:\/\/([^\/]*panopto\.[^\/]+)\/Panopto\/.+\?id=(.+)$/);
+    const matches = url.match(/^[^\/]+:\/\/([^\/]+)\/Panopto\/.+\?id=(.+)$/);
     if (matches && matches.length === 3) {
       return [matches[1], matches[2]];
     }


### PR DESCRIPTION
When merged in, will allow authors to use Panopto videos from self-hosted Panopto instances.

Is accompanied by https://github.com/h5p/h5p-editor-php-library/pull/310