### PR TITLE
Fix: make echo360.js work in strict mode

### DIFF
--- a/scripts/echo360.js
+++ b/scripts/echo360.js
@@ -226,7 +226,7 @@ H5P.VideoEchoVideo = (() => {
         previousTickMS = time;
       }
       else {
-        delete previousTickMS;
+        previousTickMS = undefined;
       }
     }
 


### PR DESCRIPTION
Root Cause:

"delete" doesn't work on a variable declared with "let".

Changes:

Assigning the variable "undefined". This has the same effect, and should work in strict mode.

According to [the doc](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Delete_in_strict_mode):
> Normal variables in JavaScript can't be deleted using the delete operator. In strict mode, an attempt to delete a variable will throw an error and is not allowed.

This is affecting h5p users, for example, see [this issue](https://github.com/Lumieducation/H5P-Nodejs-library/issues/4197).

According to git blame, cc: @otacke 