### PR TITLE
AU-8027 Use proper getter for youtube iframe

### DIFF
--- a/scripts/youtube.js
+++ b/scripts/youtube.js
@@ -166,7 +166,7 @@ H5P.VideoYouTube = (function ($) {
           }
         }
       });
-      player.g.style = "position:absolute;top:0;left:0;width:100%;height:100%;";
+      player.getIframe().style = "position:absolute;top:0;left:0;width:100%;height:100%;";
     };
 
     /**


### PR DESCRIPTION
Thank you for your interest in contributing to H5P! 🎉  
Please fill in the below sections to make your pull request:

**What kind of change does this PR introduce?**
Bug fix

**What is the current behaviour?**
 Youtube videos cannot properly set styling, so the visual part of the video is not visible.

**What is the new behaviour?**
 Using correct getter from the youtube iframe api so that the visual part of the video is visible.

## PR Checklist

Before submitting, please confirm:

- [x] I searched for existing issues/PRs first
- [x] I linked related issues/discussions
- [x] I tested my changes locally

Read the [contribution guidelines](https://github.com/h5p/.github/blob/master/CONTRIBUTING.md) to get your pr accepted more quickly.
